### PR TITLE
Add supported_schedules

### DIFF
--- a/src/spaceone/inventory/error/collector.py
+++ b/src/spaceone/inventory/error/collector.py
@@ -87,3 +87,7 @@ class ERROR_RESOURCE_KEYS_NOT_DEFINED(ERROR_BASE):
 
 class ERROR_TOO_MANY_MATCH(ERROR_BASE):
     _message = "match_key: {match_key}, matched_resources: {resources}, more: {more}"
+
+
+class ERROR_UNSUPPORTED_SCHEDULE(ERROR_BASE):
+    _message = "supported schedules: {supported}, requested: {requested}"

--- a/src/spaceone/inventory/service/collector_service.py
+++ b/src/spaceone/inventory/service/collector_service.py
@@ -195,6 +195,9 @@ class CollectorService(BaseService):
         collector_vo = collector_mgr.get_collector(collector_id, domain_id)
         params['collector'] = collector_vo
 
+        # Check schedule type
+        collector_mgr.is_supported_schedule(collector_vo, params['schedule'])
+
         scheduler_info = collector_mgr.add_schedule(params)
         return scheduler_info
 


### PR DESCRIPTION
plugin should provide metadata.supported_schedule

ex)
collector.plugin_info.metadata.supported_schedule = ['interval',
'hours', 'cron']

When creating schedule in collector, only supported schedule can be
created.

Signed-off-by: “Choonho <choonhoson@megazone.com>